### PR TITLE
Move from `asyncio` module name to `uasyncio`

### DIFF
--- a/tm1640.py
+++ b/tm1640.py
@@ -146,7 +146,7 @@ def scroll_text(tm1640, text, delay=40):
         tm1640.write_hmsb(buf)
         sleep_ms(delay)
 
-from asyncio import sleep_ms as a_sleep_ms
+from uasyncio import sleep_ms as a_sleep_ms
 async def async_scroll_text(tm1640, text, delay=40):
     buf = bytearray(8)
     fb = framebuf.FrameBuffer(buf, 8, 8, framebuf.MONO_HMSB)


### PR DESCRIPTION
This fixes the import breaking in newer versions of MicroPython (tested on 1.11). No compatibility is provided for cpython to use `asyncio` given that `micropython` is imported at the top of the file, rendering it previously incompatible.